### PR TITLE
Fix setChannelVariableAsInt function

### DIFF
--- a/src/channel.cpp
+++ b/src/channel.cpp
@@ -398,7 +398,7 @@ NAN_METHOD(Channel::SetVarAsInt)
         return Error::throwException(error);
     }
     
-    if((error = ts3client_setChannelVariableAsUInt64(scHandlerID, channelID, flag, variable)) != ERROR_ok)
+    if((error = ts3client_setChannelVariableAsInt(scHandlerID, channelID, flag, variable)) != ERROR_ok)
     {
         return Error::throwException(error);
     }


### PR DESCRIPTION
It was calling the UInt64 variant which caused an error.