### PR TITLE
Fix memory leaks when using Argument::get for strings

### DIFF
--- a/src/capture.cpp
+++ b/src/capture.cpp
@@ -55,6 +55,8 @@ NAN_METHOD(Capture::OpenDevice)
         return Error::throwException(error);
     }
     
+    freeMemory(mode);
+    freeMemory(device);
     ts3client_freeMemory(modeDefault);
     ts3client_freeMemory(deviceDefault);
 }
@@ -199,6 +201,7 @@ NAN_METHOD(Capture::ListDevices)
     
     info.GetReturnValue().Set(arr);
     
+    freeMemory(mode);
     ts3client_freeMemory(modeDefault);
     ts3client_freeMemory(deviceDefault);
     ts3client_freeMemory(devices);
@@ -330,6 +333,8 @@ NAN_METHOD(Capture::GetInfoValue)
     }
     
     info.GetReturnValue().Set(Nan::New<v8::Number>(val));
+    
+    freeMemory(key);
 }
 
 /**
@@ -364,6 +369,7 @@ NAN_METHOD(Capture::GetConfigValue)
     
     info.GetReturnValue().Set(Nan::New(val).ToLocalChecked());
     
+    freeMemory(key);
     ts3client_freeMemory(val);
 }
 
@@ -401,6 +407,9 @@ NAN_METHOD(Capture::SetConfigValue)
     {
         return Error::throwException(error);
     }
+
+    freeMemory(key);
+    freeMemory(val);
 }
 
 /**
@@ -435,5 +444,6 @@ NAN_METHOD(Capture::GetEncoderValue)
     
     info.GetReturnValue().Set(Nan::New(val).ToLocalChecked());
     
+    freeMemory(key);
     ts3client_freeMemory(val);
 }

--- a/src/channel.cpp
+++ b/src/channel.cpp
@@ -487,7 +487,7 @@ NAN_METHOD(Channel::SetVarAsString)
         return Error::throwException(error);
     }
     
-    ts3client_freeMemory(variable);
+    freeMemory(variable);
 }
 
 /**

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -174,6 +174,8 @@ NAN_METHOD(Client::SetOwnVarAsString)
     {
         return Error::throwException(error);
     }
+
+    freeMemory(variable);
 }
 
 /**
@@ -254,6 +256,7 @@ NAN_METHOD(Client::GetClones)
     
     info.GetReturnValue().Set(Nan::New(returnCode).ToLocalChecked());
     
+    freeMemory(clientUID);
     free(returnCode);
     free(defretCode);
 }
@@ -664,6 +667,7 @@ NAN_METHOD(Client::Move)
     
     info.GetReturnValue().Set(Nan::New(returnCode).ToLocalChecked());
     
+    freeMemory(password);
     free(returnCode);
     free(defretCode);
 }
@@ -712,6 +716,7 @@ NAN_METHOD(Client::KickFromChannel)
     
     info.GetReturnValue().Set(Nan::New(returnCode).ToLocalChecked());
     
+    freeMemory(reason);
     free(returnCode);
     free(defretCode);
 }
@@ -760,6 +765,7 @@ NAN_METHOD(Client::KickFromServer)
     
     info.GetReturnValue().Set(Nan::New(returnCode).ToLocalChecked());
     
+    freeMemory(reason);
     free(returnCode);
     free(defretCode);
 }
@@ -808,6 +814,7 @@ NAN_METHOD(Client::SendMessage)
     
     info.GetReturnValue().Set(Nan::New(returnCode).ToLocalChecked());
     
+    freeMemory(message);
     free(returnCode);
     free(defretCode);
 }

--- a/src/clientlib.cpp
+++ b/src/clientlib.cpp
@@ -85,6 +85,9 @@ NAN_METHOD(ClientLib::Init)
     {
         return Error::throwException(error);
     }
+
+    freeMemory(logPath);
+    freeMemory(resPath);
 }
 
 /**

--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -123,7 +123,13 @@ NAN_METHOD(Connection::Start)
     {
         return Error::throwException(error);
     }
-    
+
+    freeMemory(identity);
+    freeMemory(host);
+    freeMemory(nickname);
+    freeMemory(channelPwd);
+    freeMemory(serverPwd);
+
     for(int i = 0; i < (int) channelArr.size(); ++i)
     {
         free(channelArr[i]);
@@ -196,6 +202,12 @@ NAN_METHOD(Connection::StartWithChannelID)
     {
         return Error::throwException(error);
     }
+
+    freeMemory(identity);
+    freeMemory(host);
+    freeMemory(nickname);
+    freeMemory(channelPwd);
+    freeMemory(serverPwd);
 }
 
 /**
@@ -226,6 +238,8 @@ NAN_METHOD(Connection::Stop)
     {
         return Error::throwException(error);
     }
+
+    freeMemory(quitMessage);
 }
 
 /**

--- a/src/filetransfer.cpp
+++ b/src/filetransfer.cpp
@@ -83,6 +83,9 @@ NAN_METHOD(FileTransfer::InitUpload)
     
     info.GetReturnValue().Set(ret);
     
+    freeMemory(channelPW);
+    freeMemory(file);
+    freeMemory(srcDir);
     free(returnCode);
     free(defretCode);
 }
@@ -161,6 +164,9 @@ NAN_METHOD(FileTransfer::InitDownload)
     
     info.GetReturnValue().Set(ret);
     
+    freeMemory(channelPW);
+    freeMemory(file);
+    freeMemory(dstDir);
     free(returnCode);
     free(defretCode);
 }
@@ -263,6 +269,8 @@ NAN_METHOD(FileTransfer::GetFileList)
     
     info.GetReturnValue().Set(Nan::New(returnCode).ToLocalChecked());
     
+    freeMemory(channelPW);
+    freeMemory(path);
     free(returnCode);
     free(defretCode);
 }
@@ -317,6 +325,8 @@ NAN_METHOD(FileTransfer::GetFileInfo)
     
     info.GetReturnValue().Set(Nan::New(returnCode).ToLocalChecked());
     
+    freeMemory(channelPW);
+    freeMemory(file);
     free(returnCode);
     free(defretCode);
 }
@@ -371,6 +381,11 @@ NAN_METHOD(FileTransfer::DeleteFile)
     
     info.GetReturnValue().Set(Nan::New(returnCode).ToLocalChecked());
     
+    freeMemory(channelPW);
+    for(int i = 0; i < (int) files.size(); ++i)
+    {
+        free(files[i]);
+    }
     free(returnCode);
     free(defretCode);
 }
@@ -443,6 +458,10 @@ NAN_METHOD(FileTransfer::RenameFile)
     
     info.GetReturnValue().Set(Nan::New(returnCode).ToLocalChecked());
     
+    freeMemory(frChannelPW);
+    freeMemory(toChannelPW);
+    freeMemory(frFile);
+    freeMemory(toFile);
     free(returnCode);
     free(defretCode);
 }
@@ -497,6 +516,8 @@ NAN_METHOD(FileTransfer::CreateDirectory)
     
     info.GetReturnValue().Set(Nan::New(returnCode).ToLocalChecked());
     
+    freeMemory(channelPW);
+    freeMemory(path);
     free(returnCode);
     free(defretCode);
 }

--- a/src/identity.cpp
+++ b/src/identity.cpp
@@ -57,5 +57,6 @@ NAN_METHOD(Identity::GetUID)
     
     info.GetReturnValue().Set(Nan::New(uid).ToLocalChecked());
     
+    freeMemory(identity);
     ts3client_freeMemory(uid);
 }

--- a/src/log.cpp
+++ b/src/log.cpp
@@ -48,6 +48,9 @@ NAN_METHOD(Log::AddMessage)
     {
         return Error::throwException(error);
     }
+
+    freeMemory(logMessage);
+    freeMemory(logChannel);
 }
 
 /**

--- a/src/playback.cpp
+++ b/src/playback.cpp
@@ -55,6 +55,8 @@ NAN_METHOD(Playback::OpenDevice)
         return Error::throwException(error);
     }
     
+    freeMemory(mode);
+    freeMemory(device);
     ts3client_freeMemory(modeDefault);
     ts3client_freeMemory(deviceDefault);
 }
@@ -135,6 +137,8 @@ NAN_METHOD(Playback::PlayWaveFile)
     {
         return Error::throwException(error);
     }
+
+    freeMemory(path);
 }
 
 /**
@@ -199,6 +203,7 @@ NAN_METHOD(Playback::ListDevices)
     
     info.GetReturnValue().Set(arr);
     
+    freeMemory(mode);
     ts3client_freeMemory(modeDefault);
     ts3client_freeMemory(deviceDefault);
     ts3client_freeMemory(devices);
@@ -330,6 +335,8 @@ NAN_METHOD(Playback::GetConfigValue)
     }
     
     info.GetReturnValue().Set(Nan::New<v8::Number>(val));
+
+    freeMemory(key);
 }
 
 /**
@@ -366,4 +373,7 @@ NAN_METHOD(Playback::SetConfigValue)
     {
         return Error::throwException(error);
     }
+
+    freeMemory(key);
+    freeMemory(val);
 }

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -274,6 +274,7 @@ NAN_METHOD(Server::SendMessage)
     
     info.GetReturnValue().Set(Nan::New(returnCode).ToLocalChecked());
     
+    freeMemory(message);
     free(returnCode);
     free(defretCode);
 }

--- a/src/shared.cpp
+++ b/src/shared.cpp
@@ -7,3 +7,9 @@
 #include "shared.h"
 
 struct ClientUIFunctions clientSDK;
+
+void freeMemory(void* ptr)
+{
+    if (ptr != nullptr)
+        free(ptr);
+}

--- a/src/shared.h
+++ b/src/shared.h
@@ -23,4 +23,6 @@
 
 extern struct ClientUIFunctions clientSDK;
 
+void freeMemory(void* ptr);
+
 #endif // ADDON_SHARED_H


### PR DESCRIPTION
Argument::get for strings or vectors of strings call malloc but were never freed